### PR TITLE
Add localize script to asset bundle

### DIFF
--- a/src/AssetBundle.php
+++ b/src/AssetBundle.php
@@ -35,6 +35,18 @@ class AssetBundle
             $in_footer = isset($data['in_footer']) ? $data['in_footer'] : true;
 
             wp_enqueue_script($handle, $this->get_base_path() . $path, [], $version, $in_footer);
+
+	        if ( isset( $data['localize'] ) ) {
+		        if ( isset( $data['localize']['object'] ) === false ) {
+			        throw new \Exception( 'Missing object name for localize ' . $handle );
+		        }
+
+		        $localize_data = isset( $data['localize']['data'] ) ? $data['localize']['data'] : array();
+
+		        wp_localize_script( $handle, $data['localize']['object'],
+			        $localize_data
+		        );
+	        }
         }
     }
 


### PR DESCRIPTION
Added localize script option to asset bundle. Example of using localize

```
    'XXXVendor' => [
                 'path'     => 'dist/vendor.js',
		'version'  => 1.473,
		'localize' => [
					'object' => 'frontend_rest_object',
					'data'   => [
						'rest_url' => get_home_url() . '/wp-json/api/v1'
					]
				]
			],
```
Usage in js

`frontend_rest_object.rest_url`

Will add this to bwp