### PR TITLE
get_image_by_size will return original image size

### DIFF
--- a/src/providers/ImageProvider.php
+++ b/src/providers/ImageProvider.php
@@ -44,7 +44,7 @@ class ImageProvider {
 	}
 
 	public function get_image_by_size_name( int $image_id, string $size_name ): string {
-		if ( function_exists( 'bfai_get_image_by_size_name' ) ) {
+		if ( function_exists( 'bfai_get_image_by_size_name' ) && $size_name !== 'original' ) {
 			return bfai_get_image_by_size_name( $image_id, $size_name );
 		}
 


### PR DESCRIPTION
Cesto imamo potrebu vratiti orginalnu sliku a ImageProvider ne poznaje tu velicinu.
Ova promjena omoguce da get_image vrati URL orginalne slike. 

$image_helper        = new ImageHelper();
$image               = $image_helper->get_image( $module['park_map_image'], 'original' ); <--- inace tu moram raditi wp_get_attachment_url
$image_minimap       = $image_helper->get_image( $module['park_map_image'], 'image_600' );

Sada bez razmisljanja pozovem orginalnu sliku isto kao image_600. Dosljedno ponasnje.